### PR TITLE
Perfect palindromic cubes change

### DIFF
--- a/solutions/code/tutorialquestions/questionf79b/PerfectPalindromicCubes.java
+++ b/solutions/code/tutorialquestions/questionf79b/PerfectPalindromicCubes.java
@@ -16,7 +16,7 @@ public class PerfectPalindromicCubes {
    */
   public static void main(String[] args) {
 
-    for (int nextCubeRoot = 0; nextCubeRoot < 2000; nextCubeRoot++) {
+    for (long nextCubeRoot = 0; nextCubeRoot < 2000; nextCubeRoot++) {
       String cubeAsString = String.valueOf(nextCubeRoot * nextCubeRoot * nextCubeRoot);
       if (isPalindrome(cubeAsString)) {
         System.out.println(nextCubeRoot + " cubed is " + cubeAsString);


### PR DESCRIPTION
Although it does not affect the solution (as the next palindromic cube is 2001^3), the data type int only allows cubes up to 1290 to be stored before an overflow occurs so all the values after this value are not being correctly checked.